### PR TITLE
Use Deface frontend overrides only for test environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ This extension maintains and displays a list of the products a user has recently
 
   If your server was running, restart it so that it can find the assets properly.
 
+5. Setup frontend views
+
+  For a quick implementation you may prefer to use the included `Deface` overrides by customizing directives in [add_recently_viewed_products.rb](https://github.com/solidusio-contrib/solidus_recently_viewed/blob/master/app/overrides/add_recently_viewed_products.rb) setting `enabled: true`.
+
+  For a more fine grained implementation you can rewrite `Deface` injected partials according to needs and use them directly in views as you prefer.
+
 ---
 
 ## Contributing

--- a/app/overrides/add_recently_viewed_products.rb
+++ b/app/overrides/add_recently_viewed_products.rb
@@ -2,12 +2,14 @@ Deface::Override.new(
   virtual_path: 'spree/shared/_products',
   name: 'add_recently_viewed_products_to_products_index',
   insert_after: "#products[data-hook], [data-hook='products']",
-  partial: 'spree/shared/add_recently_viewed_products'
+  partial: 'spree/shared/add_recently_viewed_products',
+  enabled: Rails.env.test?
 )
 
 Deface::Override.new(
   virtual_path: 'spree/products/show',
   name: 'add_recently_viewed_products_to_products_show',
   insert_after: "#product_description[data-hook], [data-hook='product_description'], [data-hook='product_show']",
-  partial: 'spree/shared/add_recently_viewed_products'
+  partial: 'spree/shared/add_recently_viewed_products',
+  enabled: Rails.env.test?
 )


### PR DESCRIPTION
Deface overrides for frontend pages are by default injected only in test
environment in order to make specs pass and as a basic working example
of how the plugin may work in real life.

Some usage instructions have been added to README in order to introduce the
change and show the plugin views usage in a real Solidus app.